### PR TITLE
Prefer the rails config/user_agents.yml over the Voight-Kampff default i...

### DIFF
--- a/lib/voight_kampff/test.rb
+++ b/lib/voight_kampff/test.rb
@@ -69,8 +69,9 @@ module VoightKampff
       @@agents ||= []
       if @@agents.empty?
 
-        base_paths = [VoightKampff.root]
+        base_paths = []
         base_paths << Rails.root if defined? Rails
+        base_paths << VoightKampff.root
         rel_path = ['config', 'user_agents.yml']
 
         base_paths.any? do |base_path|


### PR DESCRIPTION
...f it exists.

I believe this is a bug, that the current version always prefers the config file on VoightKampff.root.
