### PR TITLE
Use user_agent_string instance variable

### DIFF
--- a/lib/voight_kampff/test.rb
+++ b/lib/voight_kampff/test.rb
@@ -12,7 +12,7 @@ module VoightKampff
       load_crawlers
 
       @agent ||= @@crawlers.find do |crawler|
-        user_agent_string =~ Regexp.new(crawler['pattern'], Regexp::IGNORECASE)
+        @user_agent_string =~ Regexp.new(crawler['pattern'], Regexp::IGNORECASE)
       end || {}
     end
 

--- a/voight_kampff.gemspec
+++ b/voight_kampff.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {tests}/**/*`.split("\n")
   s.require_path  = 'lib'
 
-  s.add_dependency 'rack', '~> 1.6'
+  s.add_dependency 'rack', '~> 1.5'
 
   s.add_development_dependency 'rails', '~> 4.2'
   s.add_development_dependency 'rspec-rails', '~> 3.3'


### PR DESCRIPTION
I was getting a nil result for all bot? and human? calls. Looks like it was just because the regex was referencing a nil user_agent_string variable. Updating to reference the instance variable resolved the issue for me. 