### PR TITLE
Fix bug where are user agents were seen as humans

### DIFF
--- a/lib/voight_kampff/test.rb
+++ b/lib/voight_kampff/test.rb
@@ -12,7 +12,7 @@ module VoightKampff
       load_crawlers
 
       @agent ||= @@crawlers.find do |crawler|
-        user_agent_string =~ Regexp.new(crawler['pattern'], Regexp::IGNORECASE)
+        self.user_agent_string =~ Regexp.new(crawler['pattern'], Regexp::IGNORECASE)
       end || {}
     end
 


### PR DESCRIPTION
Not sure why this is affecting some people and not others but apparently `user_agent_string` is nil for some of them. Using `self.user_agent_string` reportedly fixes the issue as reported in https://github.com/biola/Voight-Kampff/pull/17.