### PR TITLE
Requiring a lower minimum version of rack. 1.5 instead of 1.6

### DIFF
--- a/voight_kampff.gemspec
+++ b/voight_kampff.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {tests}/**/*`.split("\n")
   s.require_path  = 'lib'
 
-  s.add_dependency 'rack', '~> 1.6'
+  s.add_dependency 'rack', '~> 1.5'
 
   s.add_development_dependency 'rails', '~> 4.2'
   s.add_development_dependency 'rspec-rails', '~> 3.3'


### PR DESCRIPTION
This adds support for Rails 4.1.x.
All the tests passed when I ran them against that version of rails.
https://github.com/biola/Voight-Kampff/issues/23