### PR TITLE
Only use Rack Request if Rack defined

### DIFF
--- a/lib/voight_kampff.rb
+++ b/lib/voight_kampff.rb
@@ -1,7 +1,7 @@
 require 'json'
 
 require 'voight_kampff/test'
-require 'voight_kampff/rack_request'
+require 'voight_kampff/rack_request' if defined?(Rack)
 require 'voight_kampff/engine' if defined?(Rails)
 
 module VoightKampff


### PR DESCRIPTION
When using this gem for processing in for example a worker script, we don't always have access to Rack.