### PR TITLE
feature: allowing to add custom patterns of replicants without overlap of config in project

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Configuration
 
 A JSON file is used to match [user agent strings](http://simplyfast.info/browser) to a list of known bots.
 
-If you'd like to use an [updated list](https://github.com/monperrus/crawler-user-agents) or make your own customizations, run `rake voight_kampff:import_user_agents`. This will download a `crawler-user-agents.json` file into the `./config` directory.
+If you'd like to add your own patterns, create file in ./config directory of your project and add patterns to `crawler-user-agents.json`.
 
 __Note:__ The pattern entries in the JSON file are evaluated as [regular expressions](http://en.wikipedia.org/wiki/Regular_expression).
 
@@ -23,13 +23,13 @@ Usage
 -----
 There are three ways to use Voight-Kampff
 
-1. Through Rack::Request such as in your [Ruby on Rails](http://rubyonrails.org) controllers:  
+1. Through Rack::Request such as in your [Ruby on Rails](http://rubyonrails.org) controllers:
    `request.bot?`
 
-2. Through the `VoightKampff` module:  
+2. Through the `VoightKampff` module:
    `VoightKampff.bot? 'your user agent string'`
 
-3. Through a `VoightKampff::Test` instance:  
+3. Through a `VoightKampff::Test` instance:
    `VoightKampff::Test.new('your user agent string').bot?`
 
 All of the above examples accept `human?` and `bot?` methods. All of these methods will return `true` or `false`.
@@ -51,12 +51,12 @@ Also, the gem no longer extends `ActionDispatch::Request` instead it extends `Ra
 
 FAQ
 ---
-__Q:__ __What's with the name?__  
+__Q:__ __What's with the name?__
 __A:__ It's the [machine in Blade Runner](http://en.wikipedia.org/wiki/Blade_Runner#Voight-Kampff_machine) that is used to test whether someone is a human or a replicant.
 
-__Q:__ __I've found a bot that isn't being matched__  
+__Q:__ __I've found a bot that isn't being matched__
 __A:__ The list is being pulled from [github.com/monperrus/crawler-user-agents](https://github.com/monperrus/crawler-user-agents).
-If you'd  like to have entries added to the list, please create a pull request with that project. Once that pull request is merged, feel free to create an issue here and I'll release a new gem version with the updated list. In the meantime you can always run `rake voight_kampff:import_user_agents` on your project to get that updated list.
+If you'd like to have entries added to the list, please create a pull request with that project. Once that pull request is merged, feel free to create an issue here and I'll release a new gem version with the updated list. In the meantime you can always run `rake voight_kampff:import_user_agents` on your project to get that updated list.
 
 __Q:__ __Why don't you use the user agent list from ______________
 If you know of a better source for a list of bot user agent strings, please create an issue and let me know. I'm open to switching to a better source or supporting multiple sources. There are others out there but I like the openness of monperrus' list.

--- a/lib/voight_kampff/test.rb
+++ b/lib/voight_kampff/test.rb
@@ -1,6 +1,6 @@
 module VoightKampff
   class Test
-    CRAWLERS_FILENAME = 'crawler-user-agents.json'
+    CRAWLERS_FILENAME = 'crawler-user-agents.json'.freeze
 
     attr_accessor :user_agent_string
 
@@ -25,15 +25,14 @@ module VoightKampff
 
     def lookup_paths
       # These paths should be orderd by priority
-      base_paths = []
+      base_paths = [VoightKampff.root]
       base_paths << Rails.root if defined? Rails
-      base_paths << VoightKampff.root
 
       base_paths.map { |p| p.join('config', CRAWLERS_FILENAME) }
     end
 
-    def preferred_path
-      lookup_paths.find { |path| File.exists? path }
+    def preferred_paths
+      lookup_paths.select { |path| File.file? path }
     end
 
     def matching_crawler
@@ -54,7 +53,9 @@ module VoightKampff
     end
 
     def crawlers
-      @@crawlers ||= JSON.load(File.open(preferred_path, 'r'))
+      @@crawlers ||= preferred_paths.reduce([]) do |paths, path|
+        paths.concat(JSON.load(File.open(path, 'r')))
+      end
     end
   end
 end

--- a/spec/internal/config/crawler-user-agents.json
+++ b/spec/internal/config/crawler-user-agents.json
@@ -1,0 +1,10 @@
+[
+  {
+    "pattern": "SputnikImageBot",
+    "addition_date": "2017/11/02"
+  },
+  {
+    "pattern": "top100.rambler.ru",
+    "addition_date": "2017/11/02"
+  }
+]

--- a/spec/support/replicants.rb
+++ b/spec/support/replicants.rb
@@ -1,5 +1,7 @@
 REPLICANTS = {
   'Googlebot' => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
   'Bingbot' => 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
-  'Yahoo! Slurp' => 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)'
+  'Yahoo! Slurp' => 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)',
+  'SputnikImageBot' => 'Mozilla/5.0 (compatible; SputnikImageBot/2.2)',
+  'top100.rambler.ru' => 'Mozilla/5.0 (compatible; top100.rambler.ru crawler)'
 }


### PR DESCRIPTION
Hello!
The problem is that when our SEO wants to add a new bot, we have to copy the whole file from the gem every time. I suggest to create the same file in the project, in which we will only add our bot patterns.

Regards, Andrew.