### PR TITLE
Force UTF-8 Encoding

### DIFF
--- a/lib/tasks/voight_kampff.rake
+++ b/lib/tasks/voight_kampff.rake
@@ -9,6 +9,6 @@ namespace :voight_kampff do
     contents = Net::HTTP.get(uri)
 
     file = File.open('./config/crawler-user-agents.json', 'w')
-    file.write(contents)
+    file.write(contents.force_encoding(Encoding::UTF_8))
   end
 end

--- a/lib/tasks/voight_kampff.rake
+++ b/lib/tasks/voight_kampff.rake
@@ -8,7 +8,11 @@ namespace :voight_kampff do
     uri = URI(args[:url])
     contents = Net::HTTP.get(uri)
 
-    file = File.open('./config/crawler-user-agents.json', 'w')
-    file.write(contents.force_encoding(Encoding::UTF_8))
+    if contents.present?
+      file = File.open('./config/crawler-user-agents.json', 'w')
+      file.write(contents.force_encoding(Encoding::UTF_8))
+    else
+      puts "voight_kampff:import_user_agents - empty file received from #{uri}"
+    end
   end
 end


### PR DESCRIPTION
This PR addresses issue #33 where the contents string was encoded as `ASCII-8BIT`, instead of `UTF-8` as it should've been.