### PR TITLE
Minor typo in link to Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Also, the gem no longer extends `ActionDispatch::Request` instead it extends `Ra
 FAQ
 ---
 __Q:__ __What's with the name?__  
-__A:__ It's the [machine in Blade Runner](http://en.wikipedia.org/wiki/Blade_Runner#Voight-Kampff_machine) that is used to test whether someone is a human or a replicant.
+__A:__ It's the [machine in Blade Runner](http://en.wikipedia.org/wiki/Blade_Runner#Voigt-Kampff_machine) that is used to test whether someone is a human or a replicant.
 
 __Q:__ __I've found a bot that isn't being matched__  
 __A:__ The list is being pulled from [github.com/monperrus/crawler-user-agents](https://github.com/monperrus/crawler-user-agents).


### PR DESCRIPTION
The folks at Wikipedia found out that Voight-Kampff was a typo on some promotional material. The correct spelling is Voigt-Kampff.
I could either change Wikipedia or change the link. I chose the latter.