### PR TITLE
Load engine if Rails::Engine defined

### DIFF
--- a/lib/voight_kampff.rb
+++ b/lib/voight_kampff.rb
@@ -3,7 +3,7 @@ require 'json'
 require 'voight_kampff/test'
 require 'voight_kampff/methods'
 require 'voight_kampff/rack_request' if defined?(Rack::Request)
-require 'voight_kampff/engine' if defined?(Rails)
+require 'voight_kampff/engine' if defined?(Rails::Engine)
 
 module VoightKampff
   class << self


### PR DESCRIPTION
I have rails defined, but no `Rails::Engine` loaded. So this is a safer alternative, probably. 

I prefer to get rid of the condition at all and mention it the README that if you'd like to use it with rails, include it this way:

```ruby
gem 'voight_kampff', require: 'voight_kampff/rails'
```

But unfortunately, this will break backward compatibility.
