### PR TITLE
Use File.exist? instead of File.exists?

### DIFF
--- a/lib/voight_kampff/test.rb
+++ b/lib/voight_kampff/test.rb
@@ -33,7 +33,7 @@ module VoightKampff
     end
 
     def preferred_path
-      lookup_paths.find { |path| File.exists? path }
+      lookup_paths.find { |path| File.exist? path }
     end
 
     def matching_crawler


### PR DESCRIPTION
In ruby 3.0 using File.exists? emits a deprecation warning. It proposes to use File.exist? instead.