### PR TITLE
Fix ruby 3 deprecation warning: File.exists?

### DIFF
--- a/lib/voight_kampff/test.rb
+++ b/lib/voight_kampff/test.rb
@@ -33,7 +33,7 @@ module VoightKampff
     end
 
     def preferred_path
-      lookup_paths.find { |path| File.exists? path }
+      lookup_paths.find { |path| File.exist? path }
     end
 
     def matching_crawler


### PR DESCRIPTION
Warning:
/home/daniel/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/voight_kampff-1.1.4/lib/voight_kampff/test.rb:36: warning: File.exists? is deprecated; use File.exist? instead