### PR TITLE
Check with `defined?` to automatically load extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,6 @@ Installation
 
 `gem install voight_kampff`
 
-If you're using Rails and want to add `ActionDispatch::Request#bot?` and `ActionDispatch::Request#human?` methods, require `voight_kampff/rails`:
-
-```Gemfile
-gem 'voight_kampff', require: 'voight_kampff/rails'
-```
-
-if you're using pure Rack, require it the following way:
-
-```Gemfile
-gem 'voight_kampff', require: 'voight_kampff/rack'
-```
-
 Configuration
 -------------
 
@@ -61,23 +49,6 @@ Version 1.0 uses a new source for a list of bot user agent strings since the old
 In general the `#bot?` command tends to include all of these and I'm sure it's unlikely that anybody was getting this granular with their bot checking. So I see it as a small price to pay for an open and up to date bot list.
 
 Also, the gem no longer extends `ActionDispatch::Request` instead it extends `Rack::Request` which `ActionDispatch::Request` inherits from. This allows the same functionality for Rails while opening the gem up to other rack-based projects.
-
-Upgrading to version 2.0
-------------------------
-
-If you use Rails and `ActionDispatch::Request#bot?` and `ActionDispatch::Request#human?` methods, change your gemfile:
-
-```diff
--gem 'voight_kampff'
-+gem 'voight_kampff', require: 'voight_kampff/rails'
-```
-
-If you use Rack, change your gemfile:
-
-```diff
--gem 'voight_kampff'
-+gem 'voight_kampff', require: 'voight_kampff/rack'
-```
 
 FAQ
 ---

--- a/lib/voight_kampff.rb
+++ b/lib/voight_kampff.rb
@@ -26,3 +26,6 @@ module VoightKampff
     end
   end
 end
+
+require 'voight_kampff/rack' if defined?(Rack)
+require 'voight_kampff/rails' if defined?(Rails::Railtie)


### PR DESCRIPTION
What about checking with `defined?(Rack)` and `defined?(Rails::Railtie)` to automatically load the available extensions? This way, the user will not have to `require: ... `.

This method is often used in Rails plugins. For example, here is an example of kaminari, a well-known plugin for pagination:

- https://github.com/kaminari/kaminari/blob/ff07a285215cfb8a5f70515e86decf4a16ff643c/kaminari-core/lib/kaminari/core.rb#L21-L24